### PR TITLE
Drop interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ In your projet repository, just enter `gad [command] (options)`.
 | __help__ | Show list of commands | |
 | __exit__ | Quit the dashboard | |
 
-You can run several commands with `&&`:
-
-    gad "sprint && review"
-
 ### Options
 
 You can manually specify any of the options on the fly:

--- a/README.md
+++ b/README.md
@@ -35,19 +35,23 @@ As [recommended by GitHub](https://github.com/blog/180-local-github-config), Gad
 
 ### Commands
 
-In your projet repository, just enter `gad`.
+In your projet repository, just enter `gad [command] (options)`.
 
-| Command | Description |
-|---|---|
-| __sprint__ | Show the state of the current sprint |
-| __sprints__ | Show the state of all sprints |
-| __backlog__ | Show the state of the backlog |
-| __review__ | Display PullRequest that are awaiting your review |
-| __changelog__ | Generate a markdown changelog of the current sprint |
-| __estimate__ | Show stories that are missing estimation |
-| __status__ | Show the status of the repository |
-| __help__ | Show list of commands |
-| __exit__ | Quit the dashboard |
+| Command | Description | Options |
+|---|---|---|
+| __sprint__ | Show the state of the current sprint | __sprint__ `-s=-1` Show the previous sprint |
+| __sprints__ | Show the state of all sprints | __limit__ `-l=2` limit the number of sprint to display |
+| __backlog__ | Show the state of the backlog | |
+| __review__ | Display PullRequest that are awaiting your review | |
+| __changelog__ | Generate a markdown changelog of the current sprint | __all__ `--all` include open issues in the changelog. __sprint__ `-s=-2` Show the changelog from two sprints ago |
+| __estimate__ | Show stories that are missing estimation | |
+| __status__ | Show the status of the repository | |
+| __help__ | Show list of commands | |
+| __exit__ | Quit the dashboard | |
+
+You can run several commands with `&&`:
+
+    gad "sprint && review"
 
 ### Options
 

--- a/gad.js
+++ b/gad.js
@@ -2,12 +2,18 @@
 
 const { execSync } = require('child_process');
 const { homedir } = require('os');
+const minimist = require('minimist');
+const GithubAgileDashboard = require('./src/GithubAgileDashboard');
+const { red } = require('./src/Util/colors');
 
 function lookup(command) { try { return execSync(command).toString().trim(); } catch (error) { return ''; } }
 function remote(url) { return (new RegExp('git@github.com:(.+)\\/(.+)\\.git', 'ig').exec(url) || new Array(3).fill(null)).slice(1); }
 
+process.on('uncaughtException', function onError(error) { console.error(red(error.message)); process.exit(1); });
+
 const [defaultOwner, defaultRepo] = remote(lookup('git -C . config --get remote.origin.url'));
-const { owner, repo, user, password, cacheDir, _: commands} = require('minimist')(process.argv.slice(2), {
+const { owner, repo, user, password, cacheDir, _: command} = minimist(process.argv.slice(2), {
+    stopEarly: true,
     default: {
         owner: defaultOwner,
         repo: defaultRepo,
@@ -26,4 +32,4 @@ const { owner, repo, user, password, cacheDir, _: commands} = require('minimist'
     }
 });
 
-module.exports = new (require('./src/GithubAgileDashboard'))(owner, repo, user, password, cacheDir, commands);
+module.exports = new GithubAgileDashboard(owner, repo, user, password, cacheDir, command.join(' '));

--- a/src/CLI.js
+++ b/src/CLI.js
@@ -76,7 +76,8 @@ class CLI extends EventEmitter {
             let line;
 
             while (line = this.commandStack.shift()) {
-                this.readline.write(`${line}\r\n`);
+                this.readline.prompt();
+                this.readline.write(`${line.trim()}\r\n`);
             }
         }
     }
@@ -94,7 +95,7 @@ class CLI extends EventEmitter {
      * Display command result
      */
     result(message) {
-        this.write(typeof message === 'string' ? message : message.join('\r\n'));
+        this.write('\r\n' + (typeof message === 'string' ? message : message.join('\r\n')) + '\r\n');
         setImmediate(this.close);
     }
 

--- a/src/CLI.js
+++ b/src/CLI.js
@@ -10,7 +10,7 @@ class CLI extends EventEmitter {
 
     /**
      * @param {String} prompt
-     * @param {Array} commandStack command stack
+     * @param {Array} commandStack Command stack
      */
     constructor(prompt = '', commandStack = []) {
         super();

--- a/src/Display/BurnDownChart.js
+++ b/src/Display/BurnDownChart.js
@@ -40,7 +40,7 @@ class BurnDownChart {
     display() {
         const { dayWidth, gutter } = this.constructor;
         const burnDown = this.getBurnDown(this.milestone);
-        const labelLength = Array.from(burnDown.keys()).reduce((max, label) => Math.max(label.length, max), 0);
+        const labelLength = Math.max(Array.from(burnDown.keys()).reduce((max, label) => Math.max(label.length, max), 0), 1);
         const maxPoints = Math.ceil(this.milestone.points);
         const pointsPerDay = maxPoints / burnDown.size;
         const lines = [

--- a/src/GitHub/Milestone.js
+++ b/src/GitHub/Milestone.js
@@ -170,11 +170,15 @@ class Milestone {
     /**
      * Returns a changelog of the sprint
      *
+     * @param {Boolean} all Display all issue (and not just those that are done)
+     *
      * @return {Array}
      */
-    displayChangelog() {
-        return ['## Changelog:'].concat(
-            this.getIssueByStatus('done')
+    displayChangelog(all = false) {
+        const issues = all ? this.issues : this.getIssueByStatus('done');
+
+        return [`# ${this.title}`, '## Changelog '].concat(
+                issues
                 .sort(Issue.sortByPoint)
                 .map(issue => `- ${issue.title}`)
         );

--- a/src/GitHub/Milestone.js
+++ b/src/GitHub/Milestone.js
@@ -1,6 +1,7 @@
 const Issue = require('./Issue');
-const DateUtil = require('../Util/DateUtil');
 const BurnDownChart = require('../Display/BurnDownChart');
+const DateUtil = require('../Util/DateUtil');
+const { green, yellow } = require('../Util/colors');
 
 class Milestone {
     /**
@@ -144,7 +145,16 @@ class Milestone {
     displaySprint() {
         const { title, length, done, todo, inProgress, readyToReview, progress, points } = this;
 
-        return `${title}  ・ 📉  ${(progress * 100).toFixed(2)}% ・ 📫  ${todo}pts ・ 🚧  ${inProgress}pts ・ 🔍  ${readyToReview}pts ・ ✅  ${done}pts ・  (${length} stories ・ ${points}pts)`;
+        return [
+            title,
+            `${green(length)} stories`,
+            `${yellow(points)} points`,
+            `📉  ${(progress * 100).toFixed(2)}%`,
+            `📫  ${todo}pts`,
+            `🚧  ${inProgress}pts`,
+            `🔍  ${readyToReview}pts`,
+            `✅  ${done}pts`,
+        ].join(' ・ ');
     }
 
     /**
@@ -155,7 +165,7 @@ class Milestone {
     displayBacklog() {
         const { title, length, points } = this;
 
-        return `${title}  ・ 📇  ${length} stories ・ ${points} points`;
+        return `${title} ・ 📇  ${green(length)} stories ・ ${yellow(points)} points`;
     }
 
     /**
@@ -178,10 +188,10 @@ class Milestone {
         const issues = all ? this.issues : this.getIssueByStatus('done');
 
         return [`# ${this.title}`, '## Changelog '].concat(
-                issues
-                .sort(Issue.sortByPoint)
-                .map(issue => `- ${issue.title}`)
-        );
+            issues
+            .sort(Issue.sortByPoint)
+            .map(issue => `- ${issue.title}`)
+        ).join('\r\n');
     }
 
 }

--- a/src/GithubAgileDashboard.js
+++ b/src/GithubAgileDashboard.js
@@ -13,7 +13,7 @@ class GithubAgileDashboard {
      * @param {String} command
      */
     constructor(owner, repo, username, password, cacheDir, command = 'status') {
-        this.cli = new CLI('gad> ', command.split('&&'));
+        this.cli = new CLI('gad> ', [command]);
         this.loader = new HttpLoader(this.setProject.bind(this), owner, repo, username.trim(), password, cacheDir);
         this.user = username.trim();
         this.project = null;


### PR DESCRIPTION
- Gad don't stay "open" after executing one command
- Commands now supports arguments (e.g. `gad changelog --all` to see all issues for the sprint)
- Errors are properly caught